### PR TITLE
Fixed realloc handling of input

### DIFF
--- a/onvif_simple_server.c
+++ b/onvif_simple_server.c
@@ -302,6 +302,7 @@ int main(int argc, char ** argv)
     }
     int input_size;
     char *input = (char *) malloc (16 * 1024 * sizeof(char));
+    log_debug("Malloc finished,input pointer points to %p",input);
     if (input == NULL) {
         log_fatal("Memory error");
         fclose(fLog);
@@ -316,7 +317,10 @@ int main(int argc, char ** argv)
         free(conf_file);
         exit(EXIT_FAILURE);
     }
-    if (realloc(input, input_size * sizeof(char)) == NULL) {
+    input = (char *) realloc(input, input_size * sizeof(char));
+    //realloc returns new address which is not always the same as "input", if not updated the old pointer address causes segmentation fault when trying to use teh variable
+    log_debug("Realloc finished,input pointer is now pointing to %p",input);
+    if (input == NULL) {
         log_fatal("Memory error trying to allocate %d bytes", input_size);
         free(input);
         fclose(fLog);


### PR DESCRIPTION
After realloc the memory address of the input buffer can change , if this happens, trying to access the input buffer causes a segmentation fault. 

Added a line to update the pointer after realloc to avoid reading old address and avoid the issue.