### PR TITLE
reboot doesn't work; fix pthread

### DIFF
--- a/device_service.c
+++ b/device_service.c
@@ -225,7 +225,7 @@ int device_system_reboot()
     sleep(1);
 
     pthread_create(&reboot_pthread, NULL, reboot_thread, NULL);
-    pthread_detach(reboot_pthread);
+    pthread_join(reboot_pthread, NULL);
 
     return ret;
 }


### PR DESCRIPTION
use `pthread_join(reboot_pthread, NULL);` , so it waits for the reboot_pthread to complete before proceeding. This ensures that the main thread does not exit prematurely,