### PR TITLE
Fix missing return in configuration file parsing

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -459,6 +459,7 @@ int process_conf_file(char *file)
         service_ctx.ifs = (char *) malloc(strlen(DEFAULT_IFS) + 1);
         strcpy(service_ctx.ifs, DEFAULT_IFS);
     }
+    return 0;
 }
 
 void free_conf_file()


### PR DESCRIPTION
Hi there!

While trying to build `onvif_simple_server` using the example build script I've encountered a recurring `Wrong syntax in configuration file`. 

If i print the return value of the method in `main`, it show a junk integer value. Adding `return 0;` to the end of the parsing loop fixes it and allows the server to start properly.
 
