### PR TITLE
Do not truncate the address

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -331,9 +331,9 @@ int get_ip_address(char *address, char *netmask, char *name)
         if ((strcmp(ifa->ifa_name, name) == 0) && (ifa->ifa_addr->sa_family == AF_INET)) {
 
             sa = (struct sockaddr_in *) ifa->ifa_addr;
-            inet_ntop(AF_INET, &(((struct sockaddr_in *)sa)->sin_addr), address, 15);
+            inet_ntop(AF_INET, &(((struct sockaddr_in *)sa)->sin_addr), address, 16);
             san = (struct sockaddr_in *) ifa->ifa_netmask;
-            inet_ntop(AF_INET, &(((struct sockaddr_in *)san)->sin_addr), netmask, 15);
+            inet_ntop(AF_INET, &(((struct sockaddr_in *)san)->sin_addr), netmask, 16);
 
             log_debug("Interface: <%s>", ifa->ifa_name);
             log_debug("Address: <%s>", address);


### PR DESCRIPTION
Hey

I've just installed https://github.com/themactep/thingino-firmware on one of my old Dafang IPCams I had lying around.

I then tried to connect it to Home Assistant using the ONVIF integration.
That failed, so I went looking.

What I discovered was that in the reply of `onvif_simple_server` to `GetCapabilities`, there were a bunch of `tt:Address` and `tt:XAddr` that contained not the IPv4 of the camera but the IPv4 of the camera missing its last digit.

Instead of `192.168.178.123`, it was just `192.168.178.12`.
Changing the DHCP assignment to something < 100 for the last octet made the ONVIF integration with HA work.

Hence, I looked at the code of `onvif_simple_server` and found these two `15` in a function that gets passed
```
    char address[16];
    char netmask[16];
```

I am by no means a C dev, so this might be very wrong, however given the observed behavior, I'm _guessing_ that this might be the issue.


Disclaimer:

I neither compiled the code nor tested if it actually solves the issue. I'm just relatively confident that that should be a 16
You tell me if this makes sense or if I just posted annoying nonsense in your issue tracker