### PR TITLE
init address lenght or it will be not correctly initialed under mac os

### DIFF
--- a/wsd_simple_server.c
+++ b/wsd_simple_server.c
@@ -514,6 +514,8 @@ int main(int argc, char **argv)  {
 
         // Read from socket
         memset(recv_buffer, '\0', RECV_BUFFER_LEN);
+        addr_len = sizeof(addr_in);  // init address
+
         if (recvfrom(sock, recv_buffer, RECV_BUFFER_LEN, 0, (struct sockaddr *) &addr_in, &addr_len) > 0) {
 
             // Check if the message is a response


### PR DESCRIPTION
    When I tried to build and run under Mac,onvif client was unable to find this wsd_simple_server, I found out it was because of the initiation of ip address structure, so I run it and test it ,after this ,I want to fix this bug.
my only change is get address length first before receive from socket, only this was add: addr_len = sizeof(addr_in);  // init address.
   I haven't test under the other platform, but I think get address size  will always be better code.

       
