### PR TITLE
feat: advertise MaxPullPoints in GetServiceCapabilities response

### DIFF
--- a/events_service.c
+++ b/events_service.c
@@ -36,7 +36,7 @@ shm_t *subs_evts;
 
 int events_get_service_capabilities()
 {
-    char ebasesubscription[8], epullpoint[8];
+    char ebasesubscription[8], epullpoint[8], emaxpullpoints[4];
 
     if ((service_ctx.events_enable == EVENTS_PULLPOINT) || (service_ctx.events_enable == EVENTS_BOTH)) {
         strcpy(epullpoint, "true");
@@ -48,16 +48,19 @@ int events_get_service_capabilities()
     } else {
         strcpy(ebasesubscription, "false");
     }
+    snprintf(emaxpullpoints, sizeof(emaxpullpoints), "%d", MAX_SUBSCRIPTIONS);
 
-    long size = cat(NULL, "events_service_files/GetServiceCapabilities.xml", 4,
+    long size = cat(NULL, "events_service_files/GetServiceCapabilities.xml", 6,
             "%EVENTS_BASESUBSCRIPTION%", ebasesubscription,
-            "%EVENTS_PULLPOINT%", epullpoint);
+            "%EVENTS_PULLPOINT%", epullpoint,
+            "%MAX_PULLPOINTS%", emaxpullpoints);
 
     output_http_headers(size);
 
-    return cat("stdout", "events_service_files/GetServiceCapabilities.xml", 4,
+    return cat("stdout", "events_service_files/GetServiceCapabilities.xml", 6,
             "%EVENTS_BASESUBSCRIPTION%", ebasesubscription,
-            "%EVENTS_PULLPOINT%", epullpoint);
+            "%EVENTS_PULLPOINT%", epullpoint,
+            "%MAX_PULLPOINTS%", emaxpullpoints);
 }
 
 int events_create_pull_point_subscription()

--- a/events_service_files/GetServiceCapabilities.xml
+++ b/events_service_files/GetServiceCapabilities.xml
@@ -46,6 +46,7 @@
                                xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
                                WSSubscriptionPolicySupport="%EVENTS_BASESUBSCRIPTION%"
                                WSPullPointSupport="%EVENTS_PULLPOINT%"
+                               MaxPullPoints="%MAX_PULLPOINTS%"
                                WSPausableSubscriptionManagerInterfaceSupport="false">
             </tev:Capabilities>
         </tev:GetServiceCapabilitiesResponse>


### PR DESCRIPTION
Fixes #50.

## Problem

`GetServiceCapabilitiesResponse` currently omits `MaxPullPoints` from `tev:Capabilities`.

The ONVIF Events Service specification defines `MaxPullPoints` (xs:integer, optional) as:
> Maximum number of supported pull point subscriptions.

Without it, ONVIF clients (VMS software, custom integrations) have no way to discover the server's concurrent subscription limit before hitting it. They must either assume an arbitrary default or probe until they receive an error.

The server already enforces a hard cap via `MAX_SUBSCRIPTIONS` (default 8, max 32 per `utils.h`). Exposing this value through the standard capability response makes it discoverable with no guesswork.

## Change

- `events_service_files/GetServiceCapabilities.xml`: add `MaxPullPoints="%MAX_PULLPOINTS%"` attribute to `tev:Capabilities`
- `events_service.c` (`events_get_service_capabilities`): format `MAX_SUBSCRIPTIONS` into a local buffer and substitute it into both `cat()` calls (size probe + stdout emit)

Two files, nine lines changed. No behaviour change for existing subscribers; purely additive to the capability response.