### PR TITLE
fix: 8 security issues (null deref, format string, deadlock, SSRF, injection, DoS)

### DIFF
--- a/deviceio_service.c
+++ b/deviceio_service.c
@@ -246,15 +246,15 @@ int deviceio_set_relay_output_state()
         if ((itoken >= 0) && (itoken < service_ctx.relay_outputs_num)) {
             if (strcasecmp("active", state) == 0) {
                 if (service_ctx.relay_outputs[itoken].idle_state == IDLE_STATE_OPEN) {
-                    sprintf(sys_command, service_ctx.relay_outputs[itoken].close);
+                    snprintf(sys_command, sizeof(sys_command), "%s", service_ctx.relay_outputs[itoken].close);
                 } else {
-                    sprintf(sys_command, service_ctx.relay_outputs[itoken].open);
+                    snprintf(sys_command, sizeof(sys_command), "%s", service_ctx.relay_outputs[itoken].open);
                 }
             } else {
                 if (service_ctx.relay_outputs[itoken].idle_state == IDLE_STATE_OPEN) {
-                    sprintf(sys_command, service_ctx.relay_outputs[itoken].open);
+                    snprintf(sys_command, sizeof(sys_command), "%s", service_ctx.relay_outputs[itoken].open);
                 } else {
-                    sprintf(sys_command, service_ctx.relay_outputs[itoken].close);
+                    snprintf(sys_command, sizeof(sys_command), "%s", service_ctx.relay_outputs[itoken].close);
                 }
             }
         } else {

--- a/events_service.c
+++ b/events_service.c
@@ -38,6 +38,10 @@ shm_t *subs_evts;
  * by clients requesting arbitrarily long termination times. */
 #define MAX_SUBSCRIPTION_SEC 86400
 
+/* Maximum PullMessages poll interval: 60 seconds. Prevents worker-thread
+ * exhaustion by clients supplying an unbounded <Timeout> value. */
+#define MAX_PULLMESSAGES_TIMEOUT_SEC 60
+
 int events_get_service_capabilities()
 {
     char ebasesubscription[8], epullpoint[8], emaxpullpoints[4];
@@ -256,7 +260,10 @@ int events_pull_messages()
         return -5;
     }
 
-    log_debug("Pull message request with timeout %d seconds and message limit %d", interval2sec(timeout), limit);
+    int timeout_sec = interval2sec(timeout);
+    if (timeout_sec > MAX_PULLMESSAGES_TIMEOUT_SEC)
+        timeout_sec = MAX_PULLMESSAGES_TIMEOUT_SEC;
+    log_debug("Pull message request with timeout %d seconds and message limit %d", timeout_sec, limit);
 
     subs_evts = (shm_t *) create_shared_memory(0);
     if (subs_evts == NULL) {
@@ -293,9 +300,9 @@ int events_pull_messages()
     // Set temporary termination time += 10 to avoid termination during this function
     time(&now);
     previous_expire_time = subs_evts->subscriptions[sub_index].expire;
-    subs_evts->subscriptions[sub_index].expire = now + interval2sec(timeout) + 10;
+    subs_evts->subscriptions[sub_index].expire = now + timeout_sec + 10;
     sem_memory_post();
-    now_p_timeout = now + interval2sec(timeout);
+    now_p_timeout = now + timeout_sec;
 
     // Check if at least 1 message was triggered
     // or SetSynchronizationPoint request is received
@@ -320,10 +327,10 @@ int events_pull_messages()
     // Set correct termination time
     time(&now);
     sem_memory_wait();
-    if (previous_expire_time > now + interval2sec(timeout)) {
+    if (previous_expire_time > now + timeout_sec) {
         subs_evts->subscriptions[sub_index].expire = previous_expire_time;
     } else {
-        subs_evts->subscriptions[sub_index].expire = now + interval2sec(timeout);
+        subs_evts->subscriptions[sub_index].expire = now + timeout_sec;
     }
     expire_time = subs_evts->subscriptions[sub_index].expire;
     sem_memory_post();

--- a/events_service.c
+++ b/events_service.c
@@ -441,17 +441,35 @@ int events_subscribe()
         return -1;
     }
 
-    /* Reject loopback callback URLs. A subscriber must not point back to the
-     * device itself: there is no legitimate service on 127.x.x.x that should
-     * receive ONVIF Notify messages, and allowing it enables SSRF. */
+    /* Reject callback URLs targeting loopback, multicast, broadcast, or the
+     * unspecified address.  None of these are valid ONVIF notification
+     * receivers; allowing them enables SSRF or traffic amplification. */
     {
         const char *host_start = strstr(address, "://");
+        const char *at;
         host_start = (host_start != NULL) ? host_start + 3 : address;
-        if ((strncmp(host_start, "127.", 4) == 0) ||
+        /* Skip RFC 3986 userinfo ("user@host") to prevent bypass via
+         * e.g. "http://evil.com@127.0.0.1/" */
+        at = strchr(host_start, '@');
+        if (at != NULL) host_start = at + 1;
+        if (/* IPv4 loopback */
+                (strncmp(host_start, "127.", 4) == 0) ||
+                /* hostname loopback */
                 (strncasecmp(host_start, "localhost", 9) == 0) ||
-                (strncmp(host_start, "[::1]", 5) == 0)) {
-            log_error("Subscribe callback URL targets loopback -- rejected: %s", address);
-            send_fault("events_service", "Sender", "ter:InvalidArgVal", "ter:InvalidArgVal", "Invalid argument", "Callback address must not be a loopback address");
+                /* IPv6 loopback */
+                (strncmp(host_start, "[::1]", 5) == 0) ||
+                /* IPv4 multicast 224.0.0.0/4: first octet 224-239 */
+                (host_start[0]=='2' && host_start[1]=='2' && host_start[2]>='4' && host_start[2]<='9' && host_start[3]=='.') ||
+                (host_start[0]=='2' && host_start[1]=='3' && host_start[2]>='0' && host_start[2]<='9' && host_start[3]=='.') ||
+                /* IPv4 broadcast (255.x.x.x is never a valid unicast destination) */
+                (strncmp(host_start, "255.", 4) == 0) ||
+                /* IPv6 multicast ff00::/8 (RFC 2732: IPv6 in URLs is bracketed) */
+                (strncasecmp(host_start, "[ff", 3) == 0) ||
+                /* Unspecified addresses */
+                (strncmp(host_start, "0.0.0.0", 7) == 0) ||
+                (strncmp(host_start, "[::]", 4) == 0)) {
+            log_error("Subscribe callback URL rejected (loopback/multicast/broadcast): %s", address);
+            send_fault("events_service", "Sender", "ter:InvalidArgVal", "ter:InvalidArgVal", "Invalid argument", "Callback address must be a routable unicast address");
             return -2;
         }
     }

--- a/events_service.c
+++ b/events_service.c
@@ -441,6 +441,22 @@ int events_subscribe()
         return -1;
     }
 
+    /* Reject loopback callback URLs. A subscriber must not point back to the
+     * device itself: there is no legitimate service on 127.x.x.x that should
+     * receive ONVIF Notify messages, and allowing it enables SSRF. */
+    {
+        const char *host_start = strstr(address, "://");
+        host_start = (host_start != NULL) ? host_start + 3 : address;
+        if ((strncmp(host_start, "127.", 4) == 0) ||
+                (strncasecmp(host_start, "localhost", 9) == 0) ||
+                (strncmp(host_start, "[::1]", 5) == 0)) {
+            log_error("Subscribe callback URL targets loopback -- rejected: %s", address);
+            send_fault("events_service", "Sender", "ter:InvalidArgVal", "ter:InvalidArgVal", "Invalid argument", "Callback address must not be a loopback address");
+            return -2;
+        }
+    }
+    log_info("Subscribe callback URL: %s", address);
+
     // TopicExpression filter is supported
     element = get_element("Filter", "Body");
     if (element == NULL) {

--- a/events_service.c
+++ b/events_service.c
@@ -34,6 +34,10 @@ extern service_context_t service_ctx;
 
 shm_t *subs_evts;
 
+/* Maximum subscription lifetime: 24 hours. Prevents slot exhaustion
+ * by clients requesting arbitrarily long termination times. */
+#define MAX_SUBSCRIPTION_SEC 86400
+
 int events_get_service_capabilities()
 {
     char ebasesubscription[8], epullpoint[8], emaxpullpoints[4];
@@ -106,6 +110,8 @@ int events_create_pull_point_subscription()
             expire_time = from_iso_date(itt);
         }
     }
+    if (expire_time > now + MAX_SUBSCRIPTION_SEC)
+        expire_time = now + MAX_SUBSCRIPTION_SEC;
 
     subs_evts = (shm_t *) create_shared_memory(0);
     if (subs_evts == NULL) {
@@ -450,6 +456,8 @@ int events_subscribe()
             expire_time = from_iso_date(itt);
         }
     }
+    if (expire_time > now + MAX_SUBSCRIPTION_SEC)
+        expire_time = now + MAX_SUBSCRIPTION_SEC;
 
     subs_evts = (shm_t *) create_shared_memory(0);
     if (subs_evts == NULL) {

--- a/onvif_simple_server.c
+++ b/onvif_simple_server.c
@@ -391,7 +391,14 @@ int main(int argc, char ** argv)
             security.nonce = get_element("Nonce", "Header");
             if (security.nonce != NULL) {
                 log_debug("Security: nonce = %s", security.nonce);
-                b64_decode((unsigned char *) security.nonce, strlen(security.nonce), nonce, &nonce_size);
+                /* Base64 of 128 bytes is at most ceil(128/3)*4 = 172 chars.
+                 * Reject oversized nonces before decode to guard the 128-byte buffer. */
+                if (strlen(security.nonce) > 172) {
+                    log_error("Nonce too large");
+                    auth_error = 3;
+                } else {
+                    b64_decode((unsigned char *) security.nonce, strlen(security.nonce), nonce, &nonce_size);
+                }
             } else {
                 auth_error = 3;
             }

--- a/ptz_service.c
+++ b/ptz_service.c
@@ -926,12 +926,36 @@ int ptz_get_status()
     }
 }
 
+/* Maximum length of a preset name (without null terminator). */
+#define MAX_PRESET_NAME_LEN 64
+
+/* Returns 1 if s is a valid preset name: 1-MAX_PRESET_NAME_LEN chars,
+ * alphanumeric plus underscore, hyphen and dot only.  Spaces and shell
+ * metacharacters (;|$`&<>!*?\) are rejected to prevent command injection
+ * when the name is interpolated into a shell command via system(). */
+static int is_safe_preset_name(const char *s)
+{
+    size_t i, len;
+    if (s == NULL)
+        return 0;
+    len = strlen(s);
+    if (len == 0 || len > MAX_PRESET_NAME_LEN)
+        return 0;
+    for (i = 0; i < len; i++) {
+        char c = s[i];
+        if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+              (c >= '0' && c <= '9') || c == '_' || c == '.' || c == '-'))
+            return 0;
+    }
+    return 1;
+}
+
 int ptz_set_preset()
 {
     int i;
     char sys_command[MAX_LEN];
     const char *preset_name;
-    char preset_name_out[UUID_LEN + 8];
+    char preset_name_out[MAX_PRESET_NAME_LEN + 1];
     const char *preset_token;
     ezxml_t node;
     char preset_token_out[16];
@@ -962,15 +986,15 @@ int ptz_set_preset()
         if (preset_name == NULL) {
             // No name and no token, how to identify it? Create a random name.
             gen_uuid(name_uuid);
-            sprintf(preset_name_out, "Preset_%s", name_uuid);
+            snprintf(preset_name_out, sizeof(preset_name_out), "Preset_%s", name_uuid);
         } else {
-            strcpy(preset_name_out, preset_name);
-        }
-
-        if ((strchr(preset_name_out, ' ') != NULL) || (strlen(preset_name_out) == 0) || (strlen(preset_name_out) > 64)) {
-            destroy_presets();
-            send_fault("ptz_service", "Sender", "ter:InvalidArgVal", "ter:InvalidPresetName", "Invalid preset name", "The preset name is either too long or contains invalid characters");
-            return -3;
+            if (!is_safe_preset_name(preset_name)) {
+                destroy_presets();
+                send_fault("ptz_service", "Sender", "ter:InvalidArgVal", "ter:InvalidPresetName", "Invalid preset name", "The preset name is either too long or contains invalid characters");
+                return -3;
+            }
+            strncpy(preset_name_out, preset_name, sizeof(preset_name_out) - 1);
+            preset_name_out[sizeof(preset_name_out) - 1] = '\0';
         }
         for (i = 0; i < presets.count; i++) {
             if (strcasecmp(presets.items[i].name, preset_name_out) == 0) {
@@ -994,7 +1018,8 @@ int ptz_set_preset()
         preset_found = 0;
         for (i = 0; i < presets.count; i++) {
             if (presets.items[i].number == preset_number) {
-                strcpy(preset_name_out, presets.items[i].name);
+                strncpy(preset_name_out, presets.items[i].name, sizeof(preset_name_out) - 1);
+                preset_name_out[sizeof(preset_name_out) - 1] = '\0';
                 preset_found = 1;
                 break;
             }
@@ -1007,14 +1032,13 @@ int ptz_set_preset()
 
         if (preset_name != NULL) {
             // Overwrite the name with the new one
+            if (!is_safe_preset_name(preset_name)) {
+                destroy_presets();
+                send_fault("ptz_service", "Sender", "ter:InvalidArgVal", "ter:InvalidPresetName", "Invalid preset name", "The preset name is either too long or contains invalid characters");
+                return -7;
+            }
             memset(preset_name_out, '\0', sizeof(preset_name_out));
-            strncpy(preset_name_out, preset_name, strlen(preset_name));
-        }
-
-        if ((strchr(preset_name_out, ' ') != NULL) || (strlen(preset_name_out) == 0) || (strlen(preset_name_out) > 64)) {
-            destroy_presets();
-            send_fault("ptz_service", "Sender", "ter:InvalidArgVal", "ter:InvalidPresetName", "Invalid preset name", "The preset name is either too long or contains invalid characters");
-            return -7;
+            strncpy(preset_name_out, preset_name, sizeof(preset_name_out) - 1);
         }
 
         for (i = 0; i < presets.count; i++) {

--- a/utils.c
+++ b/utils.c
@@ -1312,9 +1312,19 @@ void gen_uuid_v5_mac(char *uuid_str, const uint8_t mac[6])
 int get_from_query_string(char **ret, int *ret_size, char *par)
 {
     char *query_string = getenv("QUERY_STRING");
-    char *query = strdup(query_string);
-    char *tokens = query;
-    char *p = query;
+    char *query;
+    char *tokens;
+    char *p;
+
+    *ret = NULL;
+    *ret_size = -1;
+
+    if (query_string == NULL)
+        return -1;
+
+    query = strdup(query_string);
+    tokens = query;
+    p = query;
 
     while ((p = strsep (&tokens, "&\n"))) {
         char *var = strtok (p, "=");

--- a/utils.c
+++ b/utils.c
@@ -32,6 +32,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <sys/types.h>
+#include <time.h>
 
 #ifdef HAVE_WOLFSSL
 #include <wolfssl/options.h>
@@ -189,11 +190,19 @@ void destroy_shared_memory(void *shared_area, int destroy_all)
 
 int sem_memory_wait()
 {
+    struct timespec ts;
+
     if (sem_memory_lock == SEM_FAILED) {
         log_error("Semaphore not initialized");
         return -1;
     }
-    return sem_wait(sem_memory_lock);
+    clock_gettime(CLOCK_REALTIME, &ts);
+    ts.tv_sec += 5;
+    if (sem_timedwait(sem_memory_lock, &ts) != 0) {
+        log_error("Semaphore wait timed out or failed -- semaphore may be stale");
+        return -1;
+    }
+    return 0;
 }
 
 int sem_memory_post()


### PR DESCRIPTION
Fixes for 8 security issues identified during a Claude-assisted static code review. Each fix is minimal and self-contained -- no refactoring or behavior changes beyond the security constraint.

Closes #54.

**Please review and confirm each finding independently before merging.** The AI-assisted review improves coverage but is not a substitute for human judgment.

---

## Changes

**utils.c**
- `get_from_query_string`: add NULL check for `getenv("QUERY_STRING")` before `strdup()` (null deref crash)
- `sem_memory_wait`: replace `sem_wait` with `sem_timedwait` (5s timeout) to recover from abandoned semaphore (permanent deadlock)
- Add `#include <time.h>` for `clock_gettime` / `struct timespec`

**deviceio_service.c**
- `deviceio_set_relay_output_state`: replace `sprintf(buf, config_string)` with `snprintf(buf, size, "%s", config_string)` (format string)

**onvif_simple_server.c**
- Reject nonce strings longer than 172 base64 characters before calling `b64_decode()` into a 128-byte buffer (missing bounds check)

**events_service.c**
- Cap subscription `expire_time` to `now + 86400` (24 hours) in both `events_create_pull_point_subscription` and `events_subscribe` (slot exhaustion)
- Cap `PullMessages` timeout to 60 seconds (thread exhaustion)
- Reject `127.x.x.x` / `localhost` / `[::1]` as Subscribe callback addresses (SSRF)

**ptz_service.c**
- Replace `strcpy` with bounded copy + null terminator in `ptz_set_preset`
- Replace space-only validation with an allowlist (`[a-zA-Z0-9_.-]`, max 64 chars) to block shell metacharacters interpolated into `system()` (shell injection + stack overflow)

## Test plan

- [x] Confirm NULL `QUERY_STRING` no longer crashes (call with empty env)
- [x] Confirm relay command with `%s` in config string is handled safely
- [x] Confirm server recovers when semaphore is abandoned (kill -9 a holder process)
- [x] Confirm nonce > 172 chars is rejected with auth error, not a crash
- [x] Confirm subscription with far-future termination time is capped at 24h
- [x] Confirm PullMessages with large Timeout is capped at 60s
- [x] Confirm Subscribe with `http://127.0.0.1/...` callback returns a fault
- [x] Confirm preset names with shell metacharacters are rejected