### PR TITLE
fix: correct varargs count in media2_get_profiles AEC cat() calls

### DIFF
--- a/media2_service.c
+++ b/media2_service.c
@@ -196,7 +196,7 @@ int media2_get_profiles()
                 if (typeAEC) {
                     if (service_ctx.profiles[h].audio_encoder != AUDIO_NONE) {
                         set_audio_codec(audio_enc_h, 16, service_ctx.profiles[0].audio_encoder, 2);
-                        size += cat(dest, "media2_service_files/GetProfiles_AEC.xml", 10,
+                        size += cat(dest, "media2_service_files/GetProfiles_AEC.xml", 4,
                                 "%PROFILE%", profile[h],
                                 "%AUDIO_ENCODING%", audio_enc_h);
                     }
@@ -275,7 +275,7 @@ int media2_get_profiles()
                 if (typeAEC) {
                     if (service_ctx.profiles[h].audio_encoder != AUDIO_NONE) {
                         set_audio_codec(audio_enc_h, 16, service_ctx.profiles[h].audio_encoder, 2);
-                        size += cat(dest, "media2_service_files/GetProfiles_AEC.xml", 10,
+                        size += cat(dest, "media2_service_files/GetProfiles_AEC.xml", 4,
                                 "%PROFILE%", profile[h],
                                 "%AUDIO_ENCODING%", audio_enc_h);
                     }
@@ -343,7 +343,7 @@ int media2_get_profiles()
                 if (typeAEC) {
                     if (service_ctx.profiles[h].audio_encoder != AUDIO_NONE) {
                         set_audio_codec(audio_enc_l, 16, service_ctx.profiles[h].audio_encoder, 2);
-                        size += cat(dest, "media2_service_files/GetProfiles_AEC.xml", 10,
+                        size += cat(dest, "media2_service_files/GetProfiles_AEC.xml", 4,
                                 "%PROFILE%", profile[h],
                                 "%AUDIO_ENCODING%", audio_enc_l);
                     }


### PR DESCRIPTION
## Bug

The three calls that render `GetProfiles_AEC.xml` inside `media2_get_profiles()` (media2_service.c) pass `num=10` to `cat()`, but only supply 2 key/value pairs (4 args):

```c
size += cat(dest, "media2_service_files/GetProfiles_AEC.xml", 10,
        "%PROFILE%", profile[h],
        "%AUDIO_ENCODING%", audio_enc_h);
```

`cat()` reads `num/2` pairs via `va_arg` in a loop, so with `num=10` it makes 5 iterations (10 `va_arg` calls) but only 4 real arguments were pushed. The extra `va_arg` calls read past the actual argument list, returning garbage pointers, which are then passed to `strstr()` inside `cat()` (utils.c:398) and segfault.

This branch (`typeAEC`) is only taken when a profile's `audio_encoder != AUDIO_NONE`, so any camera config with audio enabled crashes the CGI process on essentially every ONVIF Media2 `GetProfiles` call — which is one of the first calls an ONVIF Media2 client (e.g. Synology Surveillance Station) makes, so it can prevent the device from ever completing ONVIF verification.

The equivalent AEC call in `media_service.c` (ver1.0 Media service) already uses the correct count (`4`) in all 5 of its call sites, confirming this is a copy/paste bug isolated to the three call sites in `media2_service.c`.

## Root cause confirmation

Reproduced by replaying real ONVIF/DSM traffic (captured from a production Synology Surveillance Station instance that was failing to add this camera) against a locally-built AddressSanitizer instrumented binary:

```
==ERROR: AddressSanitizer: SEGV on unknown address ...
    #0 ... libc strstr internals
    #1 __interceptor_strstr
    #2 __interceptor_strstr
    #3 cat utils.c:398
    #4 media2_get_profiles media2_service.c:346
    #5 main onvif_simple_server.c:590
```

After the fix, the same captured requests (including `GetProfiles` with and without a `<Token>` filter) return valid `GetProfilesResponse` SOAP bodies with exit code 0, and no further crashes were observed across a full ONVIF Media2 verification sequence (`GetVideoEncoderConfigurations`, `GetVideoEncoderConfigurationOptions`, `GetProfiles`, `SetVideoEncoderConfiguration`, `GetStreamUri`).

## Fix

Change `num` from `10` to `4` at all three call sites (matches the actual 2 key/value pairs passed, and matches the pattern already used correctly in `media_service.c`).